### PR TITLE
fix: set the fetch depth of the checkout step to 0

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ jobs:
   conventional-commits-check:
     steps:
     - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
 
     - name: Conventional Commits Checker
       uses: davidglezz/action-conventional-commits-check@v1.0.0


### PR DESCRIPTION
With the exisitng usage example, the action [won't run](https://github.com/matous-volf/action-conventional-commits-check-test/actions/runs/12463549470/job/34786127231):

```
Checking conventional commits between ci/conventional-commits-check and main
fatal: ambiguous argument 'origin/ci/conventional-commits-check': unknown revision or path not in the working tree.
Use '--' to separate paths from revisions, like this:
'git <command> [<revision>...] -- [<file>...]'
```

Setting the checkout step's fetch depth to zero [resolves that](https://github.com/matous-volf/action-conventional-commits-check-test/pull/1/commits/fe953ac8ac779fe89cdab4d14c003ba038e7340a).